### PR TITLE
add stdin support

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,8 +57,15 @@ func main() {
 		runServerMode(config)
 		return
 	}
+	messageText := ""
 
-	messageText := pflag.Arg(0) // Get the first non-flag command-line argument.
+	// Get text from stdin and start messageText with it
+	stdin, err := readStdin()
+	if stdin != "" && err == nil {
+		messageText += stdin + "\n"
+	}
+	
+	messageText += pflag.Arg(0) // Get the first non-flag command-line argument.
 
 	bot, err := tgbotapi.NewBotAPI(config.BotKey)
 	if err != nil {
@@ -157,4 +164,12 @@ func sendTextMessage(bot *tgbotapi.BotAPI, userID int64, messageText string) err
 func notifySuccess() {
 	style := lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
 	fmt.Println(style.Render("Message sent!"))
+}
+
+func readStdin() (string, error) {
+	stdin, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return "", err
+	}
+	return string(stdin), nil
 }

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -57,14 +58,15 @@ func main() {
 		runServerMode(config)
 		return
 	}
+
 	messageText := ""
 
 	// Get text from stdin and start messageText with it
 	stdin, err := readStdin()
 	if stdin != "" && err == nil {
-		messageText += stdin + "\n"
+		messageText += stdin
 	}
-	
+
 	messageText += pflag.Arg(0) // Get the first non-flag command-line argument.
 
 	bot, err := tgbotapi.NewBotAPI(config.BotKey)
@@ -105,7 +107,7 @@ func runServerMode(config *AppConfig) {
 	for update := range updates {
 		if update.Message != nil {
 			displayDebugData(update)
-            os.Exit(0)
+			os.Exit(0)
 		}
 	}
 }


### PR DESCRIPTION
Add possibility to use the standard input related to #5 

Now it's possible to do this:
```bash
echo "some text" | telegrammer
```
and this:
```bash
echo "some text" | telegrammer "some more text"
```